### PR TITLE
move to setuptools so we can make a wheel file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 setup(name='niScope',
 	version='0.2',
 	py_modules=['niScope','niScopeTypes','ordered_symbols'],


### PR DESCRIPTION
This is so we can build a wheel file for the niscope tool.

This is the new standard for python packaging.
